### PR TITLE
Update php version for D8

### DIFF
--- a/islandora_repository_connection_config.info.yml
+++ b/islandora_repository_connection_config.info.yml
@@ -4,4 +4,4 @@ package: 'Islandora'
 configure: islandora.repository_admin
 core: 8.x
 type: module
-php: '5.5.9'
+php: '7.2'


### PR DESCRIPTION
php 5 support is being dropped:
[Drupal docs](https://www.drupal.org/docs/8/system-requirements/php-requirements)